### PR TITLE
Mc more flexible auth route

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,28 @@ Router.map(function() {
 });
 ```
 
+### Transitioning to other routes after auth
+
+The default behavior in the auth route transitions to the app's index after
+successful authentication. You may wish to implement other logic, and the auth
+route makes it easy to do so using the transitionToTargetRoute callback.
+
+```js
+//app/routes/auth.js
+import Auth from 'ember-icis-auth/routes/auth'
+import config from 'notes-dash/config/environment'
+
+export default Auth.reopen({
+  snowflake_provider: config.APP.SNOWFLAKE_PROVIDER,
+
+  transitionToTargetRoute: function(transition) {
+    console.log("We're authenticated now!");
+    this._super(transition);
+  }
+});
+```
+
+
 ## Running Tests
 
 * `ember test`

--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -26,7 +26,7 @@ export default Ember.Mixin.create({
 
         function(e) {
           if(e.status === 401) {
-            _this.authenticate();
+            _this._authenticate();
           }
           return Ember.RSVP.reject(e);
         }

--- a/addon/routes/auth.js
+++ b/addon/routes/auth.js
@@ -3,12 +3,16 @@ import Ember from 'ember';
 export default Ember.Route.extend({
   snowflake_provider: "CHANGEME",
 
-  setupController: function() {
+  beforeModel: function(transition) {
     var _this = this;
 
     OAuth.callback(this.get('snowflake_provider')).done(function(result) {
       localStorage['access_token'] = result.access_token;
-      _this.transitionTo('index');
+      _this.transitionToTargetRoute(transition);
     });
+  },
+
+  transitionToTargetRoute: function(transition) {
+    this.transitionTo('index');
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-icis-auth",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Authentication engine for ICIS applications",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Add callback, which can be overridden, when transitioning from auth route to target. This allows you to, for instance, set up a wildcard auth route that transitions to the route the user was trying to hit before they went through the OAuth process.

So for example if the app had a route like:

`this.route('auth', { path: '*target/auth' });`

The app's Auth Route could have behavior like the following to redirect back to the originating route:

```js
import Auth from 'ember-icis-auth/routes/auth';
import config from 'my-app/config/environment';

export default Auth.reopen({
  snowflake_provider: config.APP.SNOWFLAKE_PROVIDER,

  transitionToTargetRoute: function(transition) {
    var target = transition.params.auth.target;
    window.location.replace(target);
  }
});
```

Also tagged bumped version so that we can use this in the encounter doc app.