### PR TITLE
move active model adapter to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-icis-auth",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Authentication engine for ICIS applications",
   "directories": {
     "doc": "doc",
@@ -21,7 +21,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "active-model-adapter": "1.13.5",
     "broccoli-asset-rev": "^2.0.2",
     "ember-cli": "1.13.1",
     "ember-cli-app-version": "0.4.0",
@@ -44,6 +43,7 @@
     "ember-addon"
   ],
   "dependencies": {
+    "active-model-adapter": "1.13.5",
     "ember-cli-babel": "^5.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
Related to: https://trello.com/c/XfujPoUa/65-handle-401-from-snowflake-by-deleting-access-token-from-local-storage-and-running-oauth-flow

Turns out that bug is fixed by me upgrading to v0.5.0 of ember-icis-auth. Turns out that doesn't work so well because ember-icis-auth depends on active-model-adapter but doesn't list it as a dependency (just a development dependency) and encounter documentation doesn't have active-model-adapter as an explicit dependency of its own.

This pull fixes that and bumps the tiny version of the package.