### PR TITLE
Mc use mocha

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,12 +6,15 @@
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-data": "1.13.8",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.9",
+    "ember-mocha": "~0.7.0",
     "ember-qunit-notifications": "0.0.7",
+    "sinon-chai": "~2.8.0",
+    "chai-jquery": "~2.0.0",
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "oauth-js": "patricksrobertson/oauth-js#1.0.0",
-    "qunit": "~1.18.0"
+    "qunit": "~1.18.0",
+    "sinonjs": "~1.17.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,17 +1,17 @@
 {
   "name": "ember-icis-auth",
   "dependencies": {
-    "ember": "1.13.3",
+    "ember": "1.13.7",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.5",
+    "ember-data": "1.13.8",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.1",
+    "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.1",
-    "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1",
-    "oauth-js": "patricksrobertson/oauth-js#1.0.0"
+    "jquery": "^1.11.3",
+    "loader.js": "ember-cli/loader.js#3.2.1",
+    "oauth-js": "patricksrobertson/oauth-js#1.0.0",
+    "qunit": "~1.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "tests"
   },
   "scripts": {
-    "start": "ember server",
     "build": "ember build",
+    "start": "ember server",
     "test": "ember try:testall"
   },
   "repository": {
@@ -21,22 +21,23 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.0.2",
-    "ember-cli": "1.13.1",
-    "ember-cli-app-version": "0.4.0",
+    "broccoli-asset-rev": "^2.1.2",
+    "ember-cli": "1.13.8",
+    "ember-cli-app-version": "0.5.0",
     "ember-cli-content-security-policy": "0.4.0",
-    "ember-cli-dependency-checker": "^1.0.0",
+    "ember-cli-dependency-checker": "^1.0.1",
     "ember-cli-htmlbars": "0.7.9",
-    "ember-cli-htmlbars-inline-precompile": "^0.1.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-ic-ajax": "0.2.1",
-    "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.15",
+    "ember-cli-inject-live-reload": "^1.3.1",
+    "ember-cli-qunit": "^1.0.0",
     "ember-cli-release": "0.2.3",
-    "ember-cli-uglify": "^1.0.1",
-    "ember-data": "1.13.5",
-    "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-cli-sri": "^1.0.3",
+    "ember-cli-uglify": "^1.2.0",
+    "ember-data": "1.13.8",
     "ember-disable-proxy-controllers": "^1.0.0",
-    "ember-export-application-global": "^1.0.2",
+    "ember-export-application-global": "^1.0.3",
+    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-try": "0.0.6"
   },
   "keywords": [
@@ -44,7 +45,7 @@
   ],
   "dependencies": {
     "active-model-adapter": "1.13.5",
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.1.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -30,14 +30,15 @@
     "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^1.0.0",
+    "ember-cli-mocha": "^0.7.0",
     "ember-cli-release": "0.2.3",
     "ember-cli-sri": "^1.0.3",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "1.13.8",
+    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
-    "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-sinon": "^0.3.0",
     "ember-try": "0.0.6"
   },
   "keywords": [

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -28,7 +28,7 @@
   "node": false,
   "browser": false,
   "boss": true,
-  "curly": false,
+  "curly": true,
   "debug": false,
   "devel": false,
   "eqeqeq": true,
@@ -49,5 +49,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true
+  "esnext": true,
+  "unused": true
 }

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,6 +1,10 @@
 import resolver from './helpers/resolver';
-import {
-  setResolver
-} from 'ember-qunit';
+import { setResolver } from 'ember-mocha';
+import { afterEach } from 'mocha';
+import sinon from 'sinon';
 
 setResolver(resolver);
+
+afterEach(function() {
+  sinon.collection.restore();
+});

--- a/tests/unit/services/authenticator-test.js
+++ b/tests/unit/services/authenticator-test.js
@@ -1,81 +1,89 @@
-import {
-  moduleFor,
-  test
-} from 'ember-qunit';
-
+/* jshint expr:true */
+import { expect } from 'chai';
 import Ember from 'ember';
+import {
+  beforeEach,
+  afterEach
+} from 'mocha';
+import {
+  describeModule,
+  it
+} from 'ember-mocha';
 
-var oldOAuth;
-
-moduleFor('service:authenticator', {
-  // Specify the other units that are required for this test.
-  // needs: ['service:foo']
-  setup: function() {
-    oldOAuth = window.OAuth;
-    window.OAuth = {};
+describeModule(
+  'service:authenticator',
+  'AuthenticatorService',
+  {
+    // Specify the other units that are required for this test.
+    // needs: ['service:foo']
   },
+  function() {
+    beforeEach(function() {
+      this.oldOAuth = window.OAuth;
+      window.OAuth = {};
+    });
 
-  teardown: function() {
-    window.OAuth = oldOAuth;
+    afterEach(function() {
+      window.OAuth = this.oldOAuth;
+    });
+
+    it('#authenticate uses OAuth redirect with snowflake provider and auth callback url', function(done) {
+      // stub redirect
+      OAuth.redirect = function(provider, callbackUrl) {
+        expect(provider).to.equal(authenticator.get('snowflake_provider'));
+        expect(callbackUrl).to.equal('auth');
+        done();
+      };
+
+      var authenticator = this.subject();
+
+      authenticator.authenticate();
+    });
+
+    it('#callback calls OAuth.callback using snowflake provider', function(done) {
+      var deferred = Ember.$.Deferred();
+
+      //stub callback
+      OAuth.callback = function(provider) {
+        expect(provider).to.equal(authenticator.get('snowflake_provider'));
+        done();
+        return deferred;
+      };
+
+      var authenticator = this.subject();
+
+      authenticator.callback();
+    });
+
+    it('#callback sets access_token from result in localStorage', function() {
+      var deferred = Ember.$.Deferred();
+      deferred.resolve({access_token: '123unicorn'});
+
+      //stub callback
+      OAuth.callback = function() {
+        return deferred;
+      };
+
+      var authenticator = this.subject();
+
+      authenticator.callback();
+
+      expect(localStorage['access_token']).to.equal('123unicorn');
+    });
+
+    it('#callback returns the deferred object returned by OAuth', function() {
+      var deferred = Ember.$.Deferred();
+
+      //stub callback
+      OAuth.callback = function(provider) {
+        expect(provider).to.equal(authenticator.get('snowflake_provider'));
+        return deferred;
+      };
+
+      var authenticator = this.subject();
+
+      expect(authenticator.callback()).to.equal(deferred);
+    });
   }
-});
+);
 
-test('#authenticate uses OAuth redirect with snowflake provider and auth callback url', function(assert) {
-  assert.expect(2);
-
-  // stub redirect
-  OAuth.redirect = function(provider, callbackUrl) {
-    assert.equal(provider, authenticator.get('snowflake_provider'));
-    assert.equal(callbackUrl, 'auth');
-  };
-
-  var authenticator = this.subject();
-
-  authenticator.authenticate();
-});
-
-test('#callback calls OAuth.callback using snowflake provider', function(assert) {
-  assert.expect(1);
-
-  var deferred = Ember.$.Deferred();
-
-  //stub callback
-  OAuth.callback = function(provider) {
-    assert.equal(provider, authenticator.get('snowflake_provider'));
-    return deferred;
-  };
-
-  var authenticator = this.subject();
-
-  authenticator.callback();
-});
-
-test('#callback sets access_token from result in localStorage', function(assert) {
-  var deferred = Ember.$.Deferred();
-  deferred.resolve({access_token: '123unicorn'});
-
-  //stub callback
-  OAuth.callback = function() {
-    return deferred;
-  };
-
-  var authenticator = this.subject();
-
-  authenticator.callback();
-
-  assert.equal(localStorage['access_token'], '123unicorn');
-});
-
-test('#callback returns the deferred object returned by OAuth', function(assert) {
-  var deferred = Ember.$.Deferred();
-
-  //stub callback
-  OAuth.callback = function(provider) {
-    assert.equal(provider, authenticator.get('snowflake_provider'));
-    return deferred;
-  };
-
-  var authenticator = this.subject();
-
-  assert.equal(authenticator.callback(), deferred);
-});

--- a/tests/unit/services/test-authenticator-test.js
+++ b/tests/unit/services/test-authenticator-test.js
@@ -1,47 +1,43 @@
+/* jshint expr:true */
+import { expect } from 'chai';
 import {
-  moduleFor,
-  test
-} from 'ember-qunit';
+  describeModule,
+  it
+} from 'ember-mocha';
 
-moduleFor('service:test-authenticator', {
-  // Specify the other units that are required for this test.
-  // needs: ['service:foo']
-});
+describeModule(
+  'service:test-authenticator',
+  'TestAuthenticatorService',
+  {
+    // Specify the other units that are required for this test.
+    // needs: ['service:foo']
+  },
+  function() {
 
-// Replace this with your real tests.
-test('it exists', function(assert) {
-  var service = this.subject();
-  assert.ok(service);
-});
+  it('#authenticate returns a deferred object which always resolves', function(done) {
+    var authenticator = this.subject();
 
-test('#authenticate returns a deferred object which always resolves', function(assert) {
-  assert.expect(1);
-
-  var authenticator = this.subject();
-
-  authenticator.authenticate().done(function() {
-    assert.ok(true);
+    authenticator.authenticate().done(function() {
+      done();
+    });
   });
-});
 
-test('#callback returns a deferred object which resolves with the configured access_token', function(assert) {
-  assert.expect(1);
+  it('#callback returns a deferred object which resolves with the configured access_token', function(done) {
+    var authenticator = this.subject();
+    authenticator.set('access_token', 'i like turtles');
 
-  var authenticator = this.subject();
-  authenticator.set('access_token', 'i like turtles');
-
-  authenticator.callback().done(function(result) {
-    assert.equal(result.access_token, 'i like turtles');
+    authenticator.callback().done(function(result) {
+      expect(result.access_token).to.equal('i like turtles');
+      done();
+    });
   });
-});
 
-test('#callback sets the configured access_token in localStorage', function(assert) {
-  assert.expect(1);
+  it('#callback sets the configured access_token in localStorage', function() {
+    var authenticator = this.subject();
+    authenticator.set('access_token', 'boogie in your butt');
 
-  var authenticator = this.subject();
-  authenticator.set('access_token', 'boogie in your butt');
+    authenticator.callback();
 
-  authenticator.callback();
-
-  assert.equal(localStorage.access_token, 'boogie in your butt');
+    expect(localStorage.access_token).to.equal('boogie in your butt');
+  });
 });


### PR DESCRIPTION
This pull transitions the test suite to mocha, because I can't handle writing tests in qunit, especially when I need to backfill a bunch of unit tests. It also upgrades the ember dependency to 1.13.8 since that is what all of the apps using this library are on.

This supports work for: https://trello.com/c/0geD32Fx/152-encounter-documentation-app-fails-to-refresh-stale-access-tokens-when-embedded-in-iframe

Split out from addon changes in the interest of keeping the diffs and pulls clean, readable and reasonable atomic.