### PR TITLE
handle access token param

### DIFF
--- a/config/ci/kochiku.yml
+++ b/config/ci/kochiku.yml
@@ -1,0 +1,6 @@
+test_command: 'script/ci'
+
+targets:
+  - type: ember
+    workers: 1
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-icis-auth",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Authentication engine for ICIS applications",
   "directories": {
     "doc": "doc",

--- a/script/ci
+++ b/script/ci
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+function install_dependencies() {
+  yes | sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+  yes | sudo apt-get update
+  yes | sudo apt-get install libstdc++6-4.7-dev
+  npm install
+  sudo npm install -g bower
+  export PATH=$(npm bin):$PATH
+  bower install
+}
+
+function prepare_and_run() {
+  source /home/ops/.bashrc
+  install_dependencies
+  export PATH=$(npm bin):$PATH
+  export PATH=./node_modules/.bin:$PATH
+  mkdir phantomjsbin
+  ln -s /usr/bin/phantomjs2 phantomjsbin/phantomjs
+  export PATH=phantomjsbin:$PATH
+
+  ls $(npm bin)
+  ember test
+}
+
+prepare_and_run
+success=$?
+exit $success
+

--- a/tests/unit/mixins/authenticated-route-mixin-test.js
+++ b/tests/unit/mixins/authenticated-route-mixin-test.js
@@ -1,0 +1,84 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import {
+  describe,
+  it,
+  beforeEach
+} from 'mocha';
+import Ember from 'ember';
+import AuthenticatedRouteMixinMixin from 'ember-icis-auth/mixins/authenticated-route-mixin';
+import sinon from 'sinon';
+
+describe('AuthenticatedRouteMixinMixin', function() {
+  describe('#beforeModel', function() {
+    beforeEach(function() {
+      this.authenticatedRoute = Ember.Object.extend(AuthenticatedRouteMixinMixin, {
+        _super: function() {}
+      }).create({token: 'bogus'});
+
+      this.superStub = sinon.collection.stub(this.authenticatedRoute, '_super');
+
+      sinon.collection.stub(this.authenticatedRoute, 'findCurrentUser');
+    });
+
+
+    describe('when passed a queryParam containing access token', function() {
+      beforeEach(function() {
+        this.transition = {
+          queryParams: {
+            access_token: 'new access token'
+          }
+        };
+
+        localStorage['access_token'] = 'bogus';
+      });
+
+      it('sets the localStorage access_token value', function() {
+        this.authenticatedRoute.beforeModel(this.transition);
+
+        expect(localStorage['access_token']).to.
+          equal(this.transition.queryParams.access_token);
+      });
+
+      it('sets the token property', function() {
+        this.authenticatedRoute.beforeModel(this.transition);
+
+        expect(this.authenticatedRoute.get('token')).to.
+          equal(this.transition.queryParams.access_token);
+      });
+
+      it('calls super and passes it the transition', function() {
+        this.authenticatedRoute.beforeModel(this.transition);
+
+        expect(this.superStub.calledWith(this.transition)).to.be.true;
+      });
+    });
+
+    describe('when not passed a queryParam containing access token', function() {
+      beforeEach(function() {
+        this.transition = {};
+
+        localStorage['access_token'] = 'bogus';
+      });
+
+      it('leaves the localStorage access_token value unchanges', function() {
+        this.authenticatedRoute.beforeModel(this.transition);
+
+        expect(localStorage['access_token']).to.equal('bogus');
+      });
+
+      it('does not change the token property', function() {
+        this.authenticatedRoute.beforeModel(this.transition);
+
+        expect(this.authenticatedRoute.get('token')).to.equal('bogus');
+      });
+
+      it('calls super and passes it the transition', function() {
+        this.authenticatedRoute.beforeModel(this.transition);
+
+        expect(this.superStub.calledWith(this.transition)).to.be.true;
+      });
+
+    });
+  });
+});


### PR DESCRIPTION
Supports: https://trello.com/c/0geD32Fx/152-encounter-documentation-app-fails-to-refresh-stale-access-tokens-when-embedded-in-iframe

Adds support for setting access tokens via query params in authenticated routes. Also set up Kochiku so we can get our build on yo.