### PR TITLE
Add currentPracticeUser to currentUser

### DIFF
--- a/addon/models/current-user.js
+++ b/addon/models/current-user.js
@@ -4,10 +4,17 @@ export default DS.Model.extend({
   uid: DS.attr('string'),
   currentPracticeUsers: DS.hasMany('currentPracticeUser', { async: false }),
   access_roles: DS.attr(),
+  current_practice_user_uid: DS.attr('string'),
 
   practiceUser: function(uid) {
     return this.get('currentPracticeUsers').findBy('id', uid);
   },
+
+  currentPracticeUser: function() {
+    let uid = this.get('current_practice_user_uid');
+
+    return this.practiceUser(uid);
+  }.property('current_practice_user_uid'),
 
   practiceUserByPracticeId: function(practiceId) {
     return this.get('currentPracticeUsers').findBy('practiceId', parseInt(practiceId, 10));

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "sinon-chai": "~2.8.0",
     "chai-jquery": "~2.0.0",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "oauth-js": "patricksrobertson/oauth-js#1.0.0",
     "qunit": "~1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-icis-auth",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Authentication engine for ICIS applications",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
This is to help with an upcoming scheduling update which will
require that app to know about the current users currently
selected practice.