### PR TITLE
Fix for ember-cli resolving incorrect jquery version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "sinon-chai": "~2.8.0",
     "chai-jquery": "~2.0.0",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "oauth-js": "patricksrobertson/oauth-js#1.0.0",
     "qunit": "~1.18.0",


### PR DESCRIPTION
Ember-cli resolves jquery version '^1.11.3' to be 1.12, which causes
tests to fail to run.  Pinning to 1.11.3 (exactly) fixes this.

More info here: https://github.com/ember-cli/ember-cli/issues/5316