### PR TITLE
When auth fails we clear the token from local storage

### DIFF
--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -32,6 +32,7 @@ export default Ember.Mixin.create({
 
       (e) => {
         if(e.errors[0].status === '401') {
+          localStorage.removeItem('access_token');
           this.authenticator.authenticate();
         }
         return Ember.RSVP.reject(e);


### PR DESCRIPTION
This prevents some looping if we have a bad token -> snowflake login -> back here
