### PR TITLE
Encapsulate localStorage access in property & clear it when auth fails

### DIFF
--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -6,7 +6,11 @@ export default Ember.Mixin.create({
       return localStorage['access_token'];
     },
     set(_, value) {
-      localStorage['access_token'] = value;
+      if (value === undefined) {
+        localStorage.removeItem('access_token');
+      } else {
+        localStorage['access_token'] = value;
+      }
       return value;
     }
   }),
@@ -39,6 +43,7 @@ export default Ember.Mixin.create({
 
       (e) => {
         if(e.errors[0].status === '401') {
+          this.set('token', undefined);
           this.authenticator.authenticate();
         }
         return Ember.RSVP.reject(e);

--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -1,7 +1,15 @@
 import Ember from 'ember';
 
 export default Ember.Mixin.create({
-  token: localStorage['access_token'],
+  token: Ember.computed({
+    get() {
+      return localStorage['access_token'];
+    },
+    set(_, value) {
+      localStorage['access_token'] = value;
+      return value;
+    }
+  }),
   snowflake_provider: 'CHANGEME',
   snowflake_url: 'CHANGEME',
 
@@ -9,8 +17,7 @@ export default Ember.Mixin.create({
     this._super(transition);
 
     if (transition.queryParams && transition.queryParams.access_token) {
-      localStorage['access_token'] = transition.queryParams.access_token;
-      this.set('token', localStorage['access_token']);
+      this.set('token', transition.queryParams.access_token);
     }
 
     if(!this.get('token')) {

--- a/addon/mixins/authenticated-route-mixin.js
+++ b/addon/mixins/authenticated-route-mixin.js
@@ -6,7 +6,7 @@ export default Ember.Mixin.create({
       return localStorage['access_token'];
     },
     set(_, value) {
-      if (value === undefined) {
+      if (value == null) {
         localStorage.removeItem('access_token');
       } else {
         localStorage['access_token'] = value;

--- a/tests/unit/mixins/authenticated-route-mixin-test.js
+++ b/tests/unit/mixins/authenticated-route-mixin-test.js
@@ -10,17 +10,36 @@ import AuthenticatedRouteMixinMixin from 'ember-icis-auth/mixins/authenticated-r
 import sinon from 'sinon';
 
 describe('AuthenticatedRouteMixinMixin', function() {
+  beforeEach(function() {
+    this.authenticatedRoute = Ember.Object.extend(AuthenticatedRouteMixinMixin, {
+      _super: function() {}
+    }).create({token: 'bogus'});
+
+    this.superStub = sinon.collection.stub(this.authenticatedRoute, '_super');
+  });
+
+  describe('#token', function() {
+    describe('set', function() {
+      beforeEach(function() {
+        localStorage['access_token'] = 'existingtoken';
+      });
+
+      it('removes localStorage item if passed null', function() {
+        this.authenticatedRoute.set('token', null);
+        expect(localStorage.hasOwnProperty('access_token')).to.be.false;
+      });
+
+      it('removes localStorage item if passed undefined', function() {
+        this.authenticatedRoute.set('token', undefined);
+        expect(localStorage.hasOwnProperty('access_token')).to.be.false;
+      });
+    });
+  });
+
   describe('#beforeModel', function() {
     beforeEach(function() {
-      this.authenticatedRoute = Ember.Object.extend(AuthenticatedRouteMixinMixin, {
-        _super: function() {}
-      }).create({token: 'bogus'});
-
-      this.superStub = sinon.collection.stub(this.authenticatedRoute, '_super');
-
       sinon.collection.stub(this.authenticatedRoute, 'findCurrentUser');
     });
-
 
     describe('when passed a queryParam containing access token', function() {
       beforeEach(function() {


### PR DESCRIPTION
`localStorage['access_token']` was being evaluated when the mixin was loaded, which caused some testing difficulties.

Also @alexrothenberg added the token clearing from #16 to handle failed auth
