### PR TITLE
Add signable attribute to current practice user

### DIFF
--- a/addon/models/current-practice-user.js
+++ b/addon/models/current-practice-user.js
@@ -4,6 +4,7 @@ export default DS.Model.extend({
   default: DS.attr('boolean'),
   practiceId: DS.attr('number'),
   role: DS.attr('string'),
+  signable: DS.attr('boolean'),
 
   isProvider: function() {
     return this.get('role') === 'Provider';


### PR DESCRIPTION
The changes made here are for [this icisstaff PR](https://github.com/IoraHealth/IoraHealth/pull/3676).

This PR adds the `signable` attribute on the current practice user so that notes dashboard can determine who is able to sign notes.