### PR TITLE
Add support for extending token TTL in the background during use

### DIFF
--- a/addon/services/authenticator.js
+++ b/addon/services/authenticator.js
@@ -1,5 +1,8 @@
 import Ember from 'ember';
 
+const SECS_BEFORE_EXPIRY = 300; // 5 minutes in seconds
+const SECS_TO_MILLISECS = 1000; // 1 second in milliseconds
+
 export default Ember.Service.extend({
   snowflake_provider: "CHANGEME",
   snowflake_url: "https://localhost",
@@ -48,7 +51,7 @@ export default Ember.Service.extend({
 
     // Refresh access_token five minutes prior to expiry.
     const secsToExpire = result.expires_in;
-    const msRefreshTimeout = (secsToExpire - 300) * 1000;
+    const msRefreshTimeout = (secsToExpire - SECS_BEFORE_EXPIRY) * SECS_TO_MILLISECS;
     localStorage['token_refresh_at'] = new Date().valueOf() + msRefreshTimeout;
 
     this._queueTokenRefresh(msRefreshTimeout);

--- a/addon/services/authenticator.js
+++ b/addon/services/authenticator.js
@@ -9,6 +9,8 @@ export default Ember.Service.extend({
   _tokenRefreshTimer: null,
 
   init() {
+    this._super(...arguments);
+
     const refreshAt = localStorage['token_refresh_at'];
     const rightNow = new Date().valueOf();
 

--- a/addon/services/authenticator.js
+++ b/addon/services/authenticator.js
@@ -25,6 +25,8 @@ export default Ember.Service.extend({
   },
 
   _queueTokenRefresh(msTimeout) {
+    this._cancelRefreshTimer();
+
     const context = this;
     const timer = Ember.run.later(context, function () {
       const baseUrl = context.get('snowflake_url');
@@ -52,13 +54,16 @@ export default Ember.Service.extend({
     this._queueTokenRefresh(msRefreshTimeout);
   },
 
-  destroy() {
-    this._super(...arguments);
-
+  _cancelRefreshTimer() {
     const refreshTimer = this.get('_tokenRefreshTimer');
 
     if (refreshTimer) {
       Ember.run.cancel(refreshTimer);
     }
+  },
+
+  destroy() {
+    this._super(...arguments);
+    this._cancelRefreshTimer();
   }
 });

--- a/addon/services/authenticator.js
+++ b/addon/services/authenticator.js
@@ -46,15 +46,19 @@ export default Ember.Service.extend({
     return true;
   },
 
-  _tokenRefresh() {
+  tokenRefresh() {
     const baseUrl = this.get('snowflake_url');
     const accessToken = localStorage['access_token'];
     const url = `${baseUrl}/api/v1/tokens/${accessToken}/extend_token`;
 
-    Ember.$.ajax(url, {
+    return Ember.$.ajax(url, {
       method: 'PUT',
       contentType: 'application/json'
-    }).done(Ember.run.bind(this, this._oauthCallback));
+    }).then(Ember.run.bind(this, this._oauthCallback), (response) => {
+      if (response.status === 401) {
+        this.authenticate();
+      }
+    });
   },
 
   _oauthCallback(result) {

--- a/addon/services/authenticator.js
+++ b/addon/services/authenticator.js
@@ -2,14 +2,63 @@ import Ember from 'ember';
 
 export default Ember.Service.extend({
   snowflake_provider: "CHANGEME",
+  snowflake_url: "https://localhost",
+  _tokenRefreshTimer: null,
+
+  init() {
+    const refreshAt = localStorage['token_refresh_at'];
+    const rightNow = new Date().valueOf();
+
+    if (refreshAt && refreshAt > rightNow) {
+      const timeout = refreshAt - rightNow;
+      this._queueTokenRefresh(timeout);
+    }
+  },
 
   authenticate: function() {
     return OAuth.redirect(this.get('snowflake_provider'), 'auth');
   },
 
   callback: function() {
-    return OAuth.callback(this.get('snowflake_provider')).done(function(result) {
-      localStorage['access_token'] = result.access_token;
-    });
+    return OAuth.callback(this.get('snowflake_provider'))
+                .done(this._oauthCallback.bind(this));
+  },
+
+  _queueTokenRefresh(msTimeout) {
+    const context = this;
+    const timer = Ember.run.later(context, function () {
+      const baseUrl = context.get('snowflake_url');
+      const accessToken = localStorage['access_token'];
+      const url = `${baseUrl}/api/v1/tokens/${accessToken}/extend_token`;
+
+      Ember.$.ajax(url, {
+        method: 'PUT',
+        contentType: 'application/json'
+      }).done(context._oauthCallback.bind(context));
+    }, msTimeout);
+
+    this.set('_tokenRefreshTimer', timer);
+  },
+
+  _oauthCallback(result) {
+    const accessToken = result.access_token;
+    localStorage['access_token'] = accessToken;
+
+    // Refresh access_token five minutes prior to expiry.
+    const secsToExpire = result.expires_in;
+    const msRefreshTimeout = (secsToExpire - 300) * 1000;
+    localStorage['token_refresh_at'] = new Date().valueOf() + msRefreshTimeout;
+
+    this._queueTokenRefresh(msRefreshTimeout);
+  },
+
+  destroy() {
+    this._super(...arguments);
+
+    const refreshTimer = this.get('_tokenRefreshTimer');
+
+    if (refreshTimer) {
+      Ember.run.cancel(refreshTimer);
+    }
   }
 });

--- a/addon/services/authenticator.js
+++ b/addon/services/authenticator.js
@@ -16,7 +16,7 @@ export default Ember.Service.extend({
 
     if (refreshAt && refreshAt > rightNow) {
       const timeout = refreshAt - rightNow;
-      this.queueTokenRefresh(timeout);
+      this.scheduleTokenRefresh(timeout);
     }
   },
 
@@ -29,10 +29,10 @@ export default Ember.Service.extend({
                 .done(Ember.run.bind(this, this._oauthCallback));
   },
 
-  queueTokenRefresh(msTimeout) {
+  scheduleTokenRefresh(msTimeout) {
     this.cancelTokenRefresh();
 
-    const timer = Ember.run.later(this, this._tokenRefresh, msTimeout);
+    const timer = Ember.run.later(this, this.tokenRefresh, msTimeout);
 
     this.set('_tokenRefreshTimer', timer);
   },
@@ -66,7 +66,7 @@ export default Ember.Service.extend({
     const msRefreshTimeout = (secsToExpire - SECS_BEFORE_EXPIRY) * SECS_TO_MILLISECS;
     localStorage['token_refresh_at'] = new Date().valueOf() + msRefreshTimeout;
 
-    this.queueTokenRefresh(msRefreshTimeout);
+    this.scheduleTokenRefresh(msRefreshTimeout);
   },
 
   destroy() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-icis-auth",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Authentication engine for ICIS applications",
   "directories": {
     "doc": "doc",

--- a/tests/unit/services/authenticator-test.js
+++ b/tests/unit/services/authenticator-test.js
@@ -39,12 +39,12 @@ describeModule(
 
           now = new Date().valueOf();
           clock = sinon.useFakeTimers(now);
-          sinon.stub(authenticator, 'queueTokenRefresh');
+          sinon.stub(authenticator, 'scheduleTokenRefresh');
         });
 
         afterEach(function () {
           clock.restore();
-          authenticator.queueTokenRefresh.restore();
+          authenticator.scheduleTokenRefresh.restore();
           localStorage.removeItem("token_refresh_at");
         });
 
@@ -58,8 +58,8 @@ describeModule(
           });
 
           it("queues up a token refresh", function () {
-            expect(authenticator.queueTokenRefresh.calledOnce).to.be.true;
-            expect(authenticator.queueTokenRefresh.calledWith(now - refreshAt));
+            expect(authenticator.scheduleTokenRefresh.calledOnce).to.be.true;
+            expect(authenticator.scheduleTokenRefresh.calledWith(now - refreshAt));
           });
         });
 
@@ -70,7 +70,7 @@ describeModule(
           });
 
           it("does not queue up a token refresh", function () {
-            expect(authenticator.queueTokenRefresh.called).to.be.false;
+            expect(authenticator.scheduleTokenRefresh.called).to.be.false;
           });
         });
       });
@@ -142,14 +142,14 @@ describeModule(
 
           authenticator = this.subject();
 
-          sinon.spy(authenticator, 'queueTokenRefresh');
+          sinon.spy(authenticator, 'scheduleTokenRefresh');
 
           authenticator.callback();
         });
 
         afterEach(function () {
           clock.restore();
-          authenticator.queueTokenRefresh.restore();
+          authenticator.scheduleTokenRefresh.restore();
         });
 
         it("sets token_refresh_at in localStorage from result's expires_in", function () {
@@ -157,8 +157,8 @@ describeModule(
         });
 
         it('queues up a token refresh', function () {
-          expect(authenticator.queueTokenRefresh.calledOnce).to.be.true;
-          expect(authenticator.queueTokenRefresh.calledWithExactly(msTimeout)).to.be.true;
+          expect(authenticator.scheduleTokenRefresh.calledOnce).to.be.true;
+          expect(authenticator.scheduleTokenRefresh.calledWithExactly(msTimeout)).to.be.true;
         });
       });
 
@@ -177,7 +177,7 @@ describeModule(
       });
     });
 
-    describe("#queueTokenRefresh", function () {
+    describe("#scheduleTokenRefresh", function () {
       let authenticator, msTimeout;
 
       beforeEach(function () {
@@ -188,7 +188,7 @@ describeModule(
       it("calls cancelTokenRefresh to cancel any scheduled token refreshes", function () {
         sinon.spy(authenticator, 'cancelTokenRefresh');
 
-        authenticator.queueTokenRefresh(msTimeout);
+        authenticator.scheduleTokenRefresh(msTimeout);
 
         expect(authenticator.cancelTokenRefresh.calledOnce).to.be.true;
 
@@ -198,9 +198,9 @@ describeModule(
       it("schedules a token refresh with the Ember run loop", function () {
         sinon.spy(Ember.run, 'later');
 
-        authenticator.queueTokenRefresh(msTimeout);
+        authenticator.scheduleTokenRefresh(msTimeout);
 
-        expect(Ember.run.later.calledWith(authenticator, authenticator._tokenRefresh, msTimeout)).to.be.true;
+        expect(Ember.run.later.calledWith(authenticator, authenticator.tokenRefresh, msTimeout)).to.be.true;
 
         Ember.run.later.restore();
       });
@@ -210,7 +210,7 @@ describeModule(
 
         sinon.stub(Ember.run, 'later').returns(timerResponse);
 
-        authenticator.queueTokenRefresh(msTimeout);
+        authenticator.scheduleTokenRefresh(msTimeout);
 
         expect(authenticator.get('_tokenRefreshTimer')).to.eq(timerResponse);
 

--- a/tests/unit/services/authenticator-test.js
+++ b/tests/unit/services/authenticator-test.js
@@ -3,12 +3,15 @@ import { expect } from 'chai';
 import Ember from 'ember';
 import {
   beforeEach,
-  afterEach
+  afterEach,
+  describe,
+  context
 } from 'mocha';
 import {
   describeModule,
   it
 } from 'ember-mocha';
+import sinon from 'sinon';
 
 describeModule(
   'service:authenticator',
@@ -27,63 +30,249 @@ describeModule(
       window.OAuth = this.oldOAuth;
     });
 
-    it('#authenticate uses OAuth redirect with snowflake provider and auth callback url', function(done) {
-      // stub redirect
-      OAuth.redirect = function(provider, callbackUrl) {
-        expect(provider).to.equal(authenticator.get('snowflake_provider'));
-        expect(callbackUrl).to.equal('auth');
-        done();
-      };
+    describe("#init", function () {
+      context("token_refresh_at exists in localStorage", function () {
+        let authenticator, clock, now;
 
-      var authenticator = this.subject();
+        beforeEach(function () {
+          authenticator = this.subject();
 
-      authenticator.authenticate();
+          now = new Date().valueOf();
+          clock = sinon.useFakeTimers(now);
+          sinon.stub(authenticator, 'queueTokenRefresh');
+        });
+
+        afterEach(function () {
+          clock.restore();
+          authenticator.queueTokenRefresh.restore();
+          localStorage.removeItem("token_refresh_at");
+        });
+
+        context("token_refresh_at is after current time", function () {
+          let refreshAt;
+
+          beforeEach(function () {
+            refreshAt = now + 100000;
+            localStorage["token_refresh_at"] = refreshAt;
+            authenticator.init();
+          });
+
+          it("queues up a token refresh", function () {
+            expect(authenticator.queueTokenRefresh.calledOnce).to.be.true;
+            expect(authenticator.queueTokenRefresh.calledWith(now - refreshAt));
+          });
+        });
+
+        context('token_refresh_at is before the current time', function () {
+          beforeEach(function () {
+            localStorage["token_refresh_at"] = now - 10000;
+            authenticator.init();
+          });
+
+          it("does not queue up a token refresh", function () {
+            expect(authenticator.queueTokenRefresh.called).to.be.false;
+          });
+        });
+      });
     });
 
-    it('#callback calls OAuth.callback using snowflake provider', function(done) {
-      var deferred = Ember.$.Deferred();
+    describe("#authenticate", function () {
+      it('uses OAuth redirect with snowflake provider and auth callback url', function(done) {
+        // stub redirect
+        OAuth.redirect = function(provider, callbackUrl) {
+          expect(provider).to.equal(authenticator.get('snowflake_provider'));
+          expect(callbackUrl).to.equal('auth');
+          done();
+        };
 
-      //stub callback
-      OAuth.callback = function(provider) {
-        expect(provider).to.equal(authenticator.get('snowflake_provider'));
-        done();
-        return deferred;
-      };
+        var authenticator = this.subject();
 
-      var authenticator = this.subject();
-
-      authenticator.callback();
+        authenticator.authenticate();
+      });
     });
 
-    it('#callback sets access_token from result in localStorage', function() {
-      var deferred = Ember.$.Deferred();
-      deferred.resolve({access_token: '123unicorn'});
+    describe("#callback", function () {
+      it('calls OAuth.callback using snowflake provider', function(done) {
+        var deferred = Ember.$.Deferred();
 
-      //stub callback
-      OAuth.callback = function() {
-        return deferred;
-      };
+        //stub callback
+        OAuth.callback = function(provider) {
+          expect(provider).to.equal(authenticator.get('snowflake_provider'));
+          done();
+          return deferred;
+        };
 
-      var authenticator = this.subject();
+        var authenticator = this.subject();
 
-      authenticator.callback();
+        authenticator.callback();
+      });
 
-      expect(localStorage['access_token']).to.equal('123unicorn');
+      it('sets access_token from result in localStorage', function() {
+        var deferred = Ember.$.Deferred();
+        deferred.resolve({access_token: '123unicorn'});
+
+        //stub callback
+        OAuth.callback = function() {
+          return deferred;
+        };
+
+        var authenticator = this.subject();
+
+        authenticator.callback();
+
+        expect(localStorage['access_token']).to.equal('123unicorn');
+      });
+
+      describe("refresh behavior", function () {
+        let deferred, expiresIn, clock, authenticator, now,
+            msTimeout, expectedTokenRefreshAt;
+
+        beforeEach(function () {
+          deferred = Ember.$.Deferred();
+          expiresIn = 600;
+          deferred.resolve({ access_token: 'deadbeef', expires_in: expiresIn });
+
+          //stub callback
+          OAuth.callback = () => deferred;
+
+          now = new Date().valueOf();
+          clock = sinon.useFakeTimers(now);
+          msTimeout = (expiresIn - 300) * 1000;
+          expectedTokenRefreshAt = now + msTimeout;
+
+          authenticator = this.subject();
+
+          sinon.spy(authenticator, 'queueTokenRefresh');
+
+          authenticator.callback();
+        });
+
+        afterEach(function () {
+          clock.restore();
+          authenticator.queueTokenRefresh.restore();
+        });
+
+        it("sets token_refresh_at in localStorage from result's expires_in", function () {
+          expect(localStorage['token_refresh_at']).to.equal(expectedTokenRefreshAt.toString());
+        });
+
+        it('queues up a token refresh', function () {
+          expect(authenticator.queueTokenRefresh.calledOnce).to.be.true;
+          expect(authenticator.queueTokenRefresh.calledWithExactly(msTimeout)).to.be.true;
+        });
+      });
+
+      it('returns the deferred object returned by OAuth', function() {
+        var deferred = Ember.$.Deferred();
+
+        //stub callback
+        OAuth.callback = function(provider) {
+          expect(provider).to.equal(authenticator.get('snowflake_provider'));
+          return deferred;
+        };
+
+        var authenticator = this.subject();
+
+        expect(authenticator.callback()).to.equal(deferred);
+      });
     });
 
-    it('#callback returns the deferred object returned by OAuth', function() {
-      var deferred = Ember.$.Deferred();
+    describe("#queueTokenRefresh", function () {
+      let authenticator, msTimeout;
 
-      //stub callback
-      OAuth.callback = function(provider) {
-        expect(provider).to.equal(authenticator.get('snowflake_provider'));
-        return deferred;
-      };
+      beforeEach(function () {
+        authenticator = this.subject();
+        msTimeout = 5000;
+      });
 
-      var authenticator = this.subject();
+      it("calls cancelTokenRefresh to cancel any scheduled token refreshes", function () {
+        sinon.spy(authenticator, 'cancelTokenRefresh');
 
-      expect(authenticator.callback()).to.equal(deferred);
+        authenticator.queueTokenRefresh(msTimeout);
+
+        expect(authenticator.cancelTokenRefresh.calledOnce).to.be.true;
+
+        authenticator.cancelTokenRefresh.restore();
+      });
+
+      it("schedules a token refresh with the Ember run loop", function () {
+        sinon.spy(Ember.run, 'later');
+
+        authenticator.queueTokenRefresh(msTimeout);
+
+        expect(Ember.run.later.calledWith(authenticator, authenticator._tokenRefresh, msTimeout)).to.be.true;
+
+        Ember.run.later.restore();
+      });
+
+      it("updates the internal timer reference", function () {
+        const timerResponse = "I am timer";
+
+        sinon.stub(Ember.run, 'later').returns(timerResponse);
+
+        authenticator.queueTokenRefresh(msTimeout);
+
+        expect(authenticator.get('_tokenRefreshTimer')).to.eq(timerResponse);
+
+        Ember.run.later.restore();
+      });
+    });
+
+    describe('#cancelTokenRefresh', function () {
+      let authenticator;
+
+      context('when a timer exists', function () {
+        let timer;
+
+        beforeEach(function () {
+          timer = 'i am timer';
+          authenticator = this.subject();
+          authenticator.set('_tokenRefreshTimer', timer);
+          sinon.stub(Ember.run, 'cancel').returns(true);
+        });
+
+        afterEach(function () {
+          Ember.run.cancel.restore();
+        });
+
+        it("calls out to cancel it in the Ember run loop", function () {
+          authenticator.cancelTokenRefresh();
+          expect(Ember.run.cancel.calledOnce).to.be.true;
+          expect(Ember.run.cancel.calledWith(timer)).to.be.true;
+        });
+
+        it("returns the result of Ember.run.cancel", function () {
+          expect(authenticator.cancelTokenRefresh()).to.be.true;
+        });
+      });
+
+      context('when a timer does not exist', function () {
+        beforeEach(function () {
+          authenticator = this.subject();
+        });
+
+        it("returns true", function () {
+          expect(authenticator.cancelTokenRefresh()).to.be.true;
+        });
+      });
+    });
+
+    describe("#destroy", function () {
+      let authenticator;
+
+      beforeEach(function () {
+        authenticator = this.subject();
+        sinon.spy(authenticator, 'cancelTokenRefresh');
+        authenticator.destroy();
+      });
+
+      afterEach(function () {
+        authenticator.cancelTokenRefresh.restore();
+      });
+
+      it("cancels any scheduled timers", function () {
+        expect(authenticator.cancelTokenRefresh.calledOnce).to.be.true;
+      });
     });
   }
 );
-


### PR DESCRIPTION
#### Why?
Users use apps through out the work day and don't want to have to re-authenticate every few hours if they're continually using an app.

#### How?
Keeps track of token expiration state in the client. Schedules a timer to refresh the access token 5 minutes before the expiration (if the user is still using the app). Snowflake has rules in place for how long they're able to do this, etc. If the access token is revoked, expires, etc., the API returns a 401, and `ember-icis-auth` forces a re-auth with Snowflake.